### PR TITLE
Catch cases where navigator.gpu is set but has no adapter.

### DIFF
--- a/src/app/Renderer.ts
+++ b/src/app/Renderer.ts
@@ -90,6 +90,9 @@ export default class Renderer extends RenderingContext {
     }
 
     const adapter = await navigator.gpu.requestAdapter()
+    if (!adapter) {
+      return undefined
+    }
     RenderingContext.$canvas = canvas
     RenderingContext.canvasContext = canvas.getContext(
       'webgpu'

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ if (renderer === undefined) {
   const previewImg = document.createElement('img')
   previewImg.src = 'no-webgpu.png'
   document.getElementById('no-webgpu-preview').appendChild(previewImg)
+
+  throw new Error('WebGPU not supported')
 }
 
 const GUI_PARAMS: IGUIParams = {


### PR DESCRIPTION
This seems to happen on Chrome Linux and matches documentation at https://developer.chrome.com/docs/web-platform/webgpu/troubleshooting-tips

With this change, instead of displaying an infinite spinner, it displays the expected error message indicating the lack of WebGPU support.